### PR TITLE
Add semantic analysis test

### DIFF
--- a/lib/semantic_analysis/symbols_table.ex
+++ b/lib/semantic_analysis/symbols_table.ex
@@ -75,9 +75,9 @@ defmodule MacroCompiler.SemanticAnalysis.SymbolsTable do
 
     if (length(a) > 0) do
       acc = [acc | a]
-      [acc | list(operation, occurrences, acc)]
+      list(operation, occurrences, acc)
     else
-      []
+      acc
     end
   end
 

--- a/test/functional/semantic_analysis/call_test.exs
+++ b/test/functional/semantic_analysis/call_test.exs
@@ -1,0 +1,31 @@
+defmodule MacroCompiler.Test.Functional.SemanticAnalysis.Call do
+  use MacroCompiler.Test.Helper.SemanticAnalysis
+
+  test_should_works(
+    "should can call a macro",
+    """
+      macro Test {
+        call ShouldCall
+      }
+
+      macro ShouldCall {
+      }
+    """
+  )
+
+  test_semantic_error(
+    "should fail when try to call an unknown macro",
+    """
+      macro Test {
+        call UnknownMacro
+      }
+    """,
+    [
+      [
+        message: ["macro ", :red, "UnknownMacro", :default_color, " is called but it has never been written."],
+        metadatas: [%MacroCompiler.Parser.Metadata{ignore: nil, line: 2, offset: 4}]
+      ]
+    ]
+  )
+end
+

--- a/test/functional/semantic_analysis/variables_test.exs
+++ b/test/functional/semantic_analysis/variables_test.exs
@@ -1,0 +1,53 @@
+defmodule MacroCompiler.Test.Functional.SemanticAnalysis.Variables do
+  use MacroCompiler.Test.Helper.SemanticAnalysis
+
+  test_should_works(
+    "should can read variables if it was written",
+    """
+      macro Test {
+        $scalar = value
+        log $scalar
+
+        @array = ($scalar)
+        log @array
+
+        %hash = (key => $scalar)
+        log %hash
+      }
+    """
+  )
+
+  test_should_works(
+    "should can read variables still that it was written at another macro",
+    """
+      macro Test {
+        log $scalar
+      }
+
+      macro SetValue {
+        $scalar = value
+      }
+    """
+  )
+
+  test_semantic_error(
+    "should fail when try to read a variable that has never been written",
+    """
+      macro Test {
+        log $scalar
+        log @array if (1)
+      }
+    """,
+    [
+      [
+        message: ["variable ", :red, "$scalar", :default_color, " is read but it has never been written."],
+        metadatas: [%MacroCompiler.Parser.Metadata{ignore: nil, line: 2, offset: 8}]
+      ],
+      [
+        message: ["variable ", :red, "@array", :default_color, " is read but it has never been written."],
+        metadatas: [%MacroCompiler.Parser.Metadata{ignore: nil, line: 2, offset: 24}]
+      ]
+    ]
+  )
+end
+

--- a/test/functional/semantic_analysis/variables_test.exs
+++ b/test/functional/semantic_analysis/variables_test.exs
@@ -30,6 +30,31 @@ defmodule MacroCompiler.Test.Functional.SemanticAnalysis.Variables do
     """
   )
 
+  test_semantic_warning(
+     "should warning when write a variable that was never read",
+     """
+       macro Test {
+         $scalar = value
+         @array = ()
+         %hash = ()
+       }
+     """,
+     [
+       [
+         message: ["variable ", :red, "$scalar", :default_color, " is write but it has never read."],
+         metadatas: [%MacroCompiler.Parser.Metadata{ignore: nil, line: 2, offset: 4}]
+       ],
+       [
+         message: ["variable ", :red, "%hash", :default_color, " is write but it has never read."],
+         metadatas: [%MacroCompiler.Parser.Metadata{ignore: nil, line: 2, offset: 40}]
+       ],
+       [
+         message: ["variable ", :red, "@array", :default_color, " is write but it has never read."],
+         metadatas: [%MacroCompiler.Parser.Metadata{ignore: nil, line: 2, offset: 24}]
+       ]
+     ]
+  )
+
   test_semantic_error(
     "should fail when try to read a variable that has never been written",
     """

--- a/test/helpers/semantic_analysis.ex
+++ b/test/helpers/semantic_analysis.ex
@@ -30,6 +30,21 @@ defmodule MacroCompiler.Test.Helper.SemanticAnalysis do
     end
   end
 
+  defmacro test_semantic_warning(description, code, compare_list) do
+    quote do
+      test unquote(description) do
+        validates_result = get_validates_result(unquote(code))
+
+        List.zip([validates_result, unquote(compare_list)])
+        |> Enum.each(fn {validate_result, [message: message, metadatas: metadatas]} ->
+          assert validate_result.message == message
+          assert validate_result.metadatas == metadatas
+          assert validate_result.type == :warning
+       end)
+      end
+    end
+  end
+
   defmacro test_semantic_error(description, code, compare_list) do
     quote do
       test unquote(description) do

--- a/test/helpers/semantic_analysis.ex
+++ b/test/helpers/semantic_analysis.ex
@@ -1,0 +1,52 @@
+defmodule MacroCompiler.Test.Helper.SemanticAnalysis do
+  alias MacroCompiler.Parser.TopLevelBlock
+  alias MacroCompiler.SemanticAnalysis
+
+  alias MacroCompiler.Error
+  alias MacroCompiler.SemanticAnalysis.FatalError, as: FatalSemanticError
+
+  defmacro __using__(_opts) do
+    quote do
+      use ExUnit.Case, async: true
+      import MacroCompiler.Test.Helper.SemanticAnalysis
+    end
+  end
+
+  def get_validates_result(code) do
+    [ast] = Combine.parse(code, TopLevelBlock.parser())
+
+    symbols_table = SemanticAnalysis.build_symbols_table(ast)
+    SemanticAnalysis.run_validates(symbols_table)
+  end
+
+  defmacro test_should_works(description, code) do
+    quote do
+      test unquote(description) do
+        validates_result = get_validates_result(unquote(code))
+
+        assert length(validates_result) == 0
+        Error.raise_fatal_error(validates_result)
+      end
+    end
+  end
+
+  defmacro test_semantic_error(description, code, compare_list) do
+    quote do
+      test unquote(description) do
+        validates_result = get_validates_result(unquote(code))
+
+        List.zip([validates_result, unquote(compare_list)])
+        |> Enum.each(fn {validate_result, [message: message, metadatas: metadatas]} ->
+          assert validate_result.message == message
+          assert validate_result.metadatas == metadatas
+          assert validate_result.type == :error
+        end)
+
+        assert_raise FatalSemanticError, fn ->
+          Error.raise_fatal_error(validates_result)
+        end
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
Add abstraction to write semantic analysis tests and a couple semantic analysis tests.

For example:

**Test if everything is fine**

```elixir
test_should_works(
  "should can call a macro",
  """
    macro Test {
      call ShouldCall
    }
    macro ShouldCall {
    }
  """
)
```

**Test if it raises a warning**

```elixir
test_semantic_warning(
   "should warning when write a variable that was never read",
   """
     macro Test {
       $scalar = value
     }
   """,
   [
     [
       message: ["variable ", :red, "$scalar", :default_color, " is write but it has never read."],
       metadatas: [%MacroCompiler.Parser.Metadata{ignore: nil, line: 2, offset: 4}]
     ]
   ]
)
```

**Test if it raises a fatal semantic analysis error**

```elixir
test_semantic_error(
  "should fail when try to call an unknown macro",
  """
    macro Test {
      call UnknownMacro
    }
  """,
  [
    [
      message: ["macro ", :red, "UnknownMacro", :default_color, " is called but it has never been written."],
      metadatas: [%MacroCompiler.Parser.Metadata{ignore: nil, line: 2, offset: 4}]
    ]
  ]
)
```